### PR TITLE
Apply some minor fixes to rwc starter code

### DIFF
--- a/week2/rwc/src/main.rs
+++ b/week2/rwc/src/main.rs
@@ -3,10 +3,10 @@ use std::process;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 3 {
+    if args.len() < 2 {
         println!("Too few arguments.");
         process::exit(1);
     }
-    let filename1 = &args[1];
+    let filename = &args[1];
     // Your code here :)
 }


### PR DESCRIPTION
wc only takes 1 argument, the filename so I imagine `args.len()` should be a minimum of 2

renamed `filename1` -> `filename`

These are super minor fixes; I imagine the starter code was copied over from the rdiff starter code, but these are changes I made to the starter code before beginning work on rwc.

The course is awesome so far! Thanks for making this public : )