### PR TITLE
fix: multiple occurrences with --upstream

### DIFF
--- a/proj-2/balancebeam/src/main.rs
+++ b/proj-2/balancebeam/src/main.rs
@@ -17,7 +17,7 @@ struct CmdOptions {
         default_value = "0.0.0.0:1100"
     )]
     bind: String,
-    #[clap(short, long, about = "Upstream host to forward requests to")]
+    #[clap(short, long, multiple_occurrences = true, about = "Upstream host to forward requests to")]
     upstream: Vec<String>,
     #[clap(
         long,


### PR DESCRIPTION
We need to add `multiple_occurrences = true` to `CmdOptions.upstream` to make sure
we can use `balancebeam` with `-u addr:port -u addr:port`, and pass the `test_load_distribution`.
Otherwise, it will occur this error:
```
error: The argument '--upstream <UPSTREAM>...' was provided more than once, but cannot be used multiple times
```