### PR TITLE
Fix renamed trait: Clap => Parser

### DIFF
--- a/proj-2/balancebeam/src/main.rs
+++ b/proj-2/balancebeam/src/main.rs
@@ -1,13 +1,13 @@
 mod request;
 mod response;
 
-use clap::Clap;
+use clap::Parser;
 use rand::{Rng, SeedableRng};
 use std::net::{TcpListener, TcpStream};
 
 /// Contains information parsed from the command-line invocation of balancebeam. The Clap macros
 /// provide a fancy way to automatically construct a command-line argument parser.
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(about = "Fun with load balancing")]
 struct CmdOptions {
     #[clap(


### PR DESCRIPTION
We will fail to build project when using `use clap::Clap;` in crate `clap = "3.0.0-beta.1` because clap has renamed trait from `clap::Clap` to `clap::Parser`.