### PR TITLE
fix clap version

### DIFF
--- a/proj-2/balancebeam/Cargo.toml
+++ b/proj-2/balancebeam/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.0-beta.1"
+clap = { version = "4.5.7", features = ["derive"] }
 httparse = "1.3"
 http = "0.2"
 log = "0.4"

--- a/proj-2/balancebeam/src/main.rs
+++ b/proj-2/balancebeam/src/main.rs
@@ -1,40 +1,37 @@
 mod request;
 mod response;
 
-use clap::Clap;
+use clap::Parser;
 use rand::{Rng, SeedableRng};
 use std::net::{TcpListener, TcpStream};
 
 /// Contains information parsed from the command-line invocation of balancebeam. The Clap macros
 /// provide a fancy way to automatically construct a command-line argument parser.
-#[derive(Clap, Debug)]
-#[clap(about = "Fun with load balancing")]
+#[derive(Parser, Debug)]
+#[command(about = "Fun with load balancing")]
 struct CmdOptions {
-    #[clap(
-        short,
-        long,
-        about = "IP/port to bind to",
-        default_value = "0.0.0.0:1100"
-    )]
+    // IP/port to bind to
+    // #[arg(short, long, default_value_t = ("0.0.0.0:1100".to_string()))]
+    #[arg(short, long, help = "IP/port to bind to", default_value_t = String::from("0.0.0.0:1100"))]
     bind: String,
-    #[clap(short, long, about = "Upstream host to forward requests to")]
+    // Upstream host to forward requests to
+    #[arg(short, long, help = "Upstream host to forward requests to")]
     upstream: Vec<String>,
-    #[clap(
+    // Perform active health checks on this interval (in seconds)
+    #[arg(
         long,
-        about = "Perform active health checks on this interval (in seconds)",
-        default_value = "10"
+        help = "Perform active health checks on this interval (in seconds)",
+        default_value_t = 10
     )]
     active_health_check_interval: usize,
-    #[clap(
-    long,
-    about = "Path to send request to for active health checks",
-    default_value = "/"
-    )]
+    // Path to send request to for active health checks
+    #[arg(long, help = "Path to send request to for active health checks",default_value_t = String::from("/"))]
     active_health_check_path: String,
-    #[clap(
+    // Maximum number of requests to accept per IP per minute (0 = unlimited)
+    #[arg(
         long,
-        about = "Maximum number of requests to accept per IP per minute (0 = unlimited)",
-        default_value = "0"
+        help = "Maximum number of requests to accept per IP per minute (0 = unlimited)",
+        default_value_t = 0
     )]
     max_requests_per_minute: usize,
 }
@@ -111,7 +108,11 @@ fn connect_to_upstream(state: &ProxyState) -> Result<TcpStream, std::io::Error> 
 
 fn send_response(client_conn: &mut TcpStream, response: &http::Response<Vec<u8>>) {
     let client_ip = client_conn.peer_addr().unwrap().ip().to_string();
-    log::info!("{} <- {}", client_ip, response::format_response_line(&response));
+    log::info!(
+        "{} <- {}",
+        client_ip,
+        response::format_response_line(&response)
+    );
     if let Err(error) = response::write_to_stream(&response, client_conn) {
         log::warn!("Failed to send response to client: {}", error);
         return;
@@ -177,7 +178,11 @@ fn handle_connection(mut client_conn: TcpStream, state: &ProxyState) {
 
         // Forward the request to the server
         if let Err(error) = request::write_to_stream(&request, &mut upstream_conn) {
-            log::error!("Failed to send request to upstream {}: {}", upstream_ip, error);
+            log::error!(
+                "Failed to send request to upstream {}: {}",
+                upstream_ip,
+                error
+            );
             let response = response::make_http_error(http::StatusCode::BAD_GATEWAY);
             send_response(&mut client_conn, &response);
             return;


### PR DESCRIPTION
When I try to compile project 2, I met error  messages .
Command 
`cargo run -- --upstream 171.67.215.200:80
`
message 
`error[E0432]: unresolved import `clap::Clap`
 --> src/main.rs:4:5
  |
4 | use clap::Clap;
  |     ^^^^^^^^^^ no `Clap` in the root

error: cannot determine resolution for the derive macro `Clap`
  --> src/main.rs:10:10
   |
10 | #[derive(Clap, Debug)]
   |          ^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: cannot find attribute `clap` in this scope
  --> src/main.rs:11:3
   |
11 | #[clap(about = "Fun with load balancing")]
   |   ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error: cannot find attribute `clap` in this scope
  --> src/main.rs:13:7
   |
13 |     #[clap(
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error: cannot find attribute `clap` in this scope
  --> src/main.rs:20:7
   |
20 |     #[clap(short, long, about = "Upstream host to forward requests to")]
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error: cannot find attribute `clap` in this scope
  --> src/main.rs:22:7
   |
22 |     #[clap(
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error: cannot find attribute `clap` in this scope
  --> src/main.rs:28:7
   |
28 |     #[clap(
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error: cannot find attribute `clap` in this scope
  --> src/main.rs:34:7
   |
34 |     #[clap(
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error[E0599]: no function or associated item named `parse` found for struct `CmdOptions` in the current scope
  --> src/main.rs:70:31
   |
12 | struct CmdOptions {
   | ----------------- function or associated item `parse` not found for this struct
...
70 |     let options = CmdOptions::parse();
   |                               ^^^^^ function or associated item not found in `CmdOptions`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `parse`, perhaps you need to implement one of them:
           candidate #1: `Parser`
           candidate #2: `TypedValueParser`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `balancebeam` (bin "balancebeam") due to 9 previous errors`

I doubt it's about Crate clap's version ,So I updated it's version and did a little change ,then It compiles .

